### PR TITLE
Support for warn/crit percentages and CISCO-POWER-ETHERNET-EXT-MIB

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Module:2 Available:370 W, Used:19 W, Remaining:351 W : OK | M2_Used=19;330;340;0
 
 
 ## Version history
+* 0.4 2020-02-12 Accept warn/crit percentages, support CISCO-POWER-ETHERNET-EXT-MIB, modified output.
 * 0.3 2019-03-06 Added performance data and modified output.
 * 0.2 2017-06-07 Fix for Cisco bug CSCtl11469. Data is now collected via a snmpwalk. Support for stacked switches.
 ___


### PR DESCRIPTION
Can now add a percent sign to warn/crit values to treat them as a percentage of available power.
Checks for devices supporting CISCO-POWER-ETHERNET-EXT-MIB and will use that if possible.  We had incorrect results from devices using POWER-ETHERNET-MIB, this fixes it.
Some changes to output messages.  Now sorts output by module number, reports max usage on first output line, etc.